### PR TITLE
Follow-up: type `PlaywrightConfig.launch_kwargs` with `BrowserType.launch` options

### DIFF
--- a/src/litestar_playwright/config.py
+++ b/src/litestar_playwright/config.py
@@ -6,15 +6,44 @@ from __future__ import annotations
 import warnings
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
-from playwright.async_api import Browser, BrowserType, Playwright, async_playwright
+from playwright.async_api import (
+    Browser,
+    BrowserType,
+    Playwright,
+    ProxySettings,
+    async_playwright,
+)
 
 if TYPE_CHECKING:
+    import pathlib
     from typing import AsyncGenerator
 
     from litestar import Litestar
     from litestar.datastructures import State
+
+
+class LaunchKwargs(TypedDict, total=False):
+    """Typed kwargs for ``playwright.async_api.BrowserType.launch()``."""
+
+    executable_path: pathlib.Path | str | None
+    channel: str | None
+    args: list[str] | None
+    ignore_default_args: bool | list[str] | None
+    handle_sigint: bool | None
+    handle_sigterm: bool | None
+    handle_sighup: bool | None
+    timeout: float | None
+    env: dict[str, str]
+    headless: bool | None
+    devtools: bool | None
+    proxy: ProxySettings | None
+    downloads_path: pathlib.Path | str | None
+    slow_mo: float | None
+    traces_dir: pathlib.Path | str | None
+    chromium_sandbox: bool | None
+    firefox_user_prefs: dict[str, str | float | bool] | None
 
 
 @dataclass
@@ -27,7 +56,7 @@ class PlaywrightConfig:
     headless: bool = False
     """Whether to run browsers in headless mode."""
 
-    launch_kwargs: dict[str, Any] = field(default_factory=dict)
+    launch_kwargs: LaunchKwargs = field(default_factory=LaunchKwargs)
     """Options to pass to the "playwright.async_api.BrowserType.launch()" method.
 
     See https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch


### PR DESCRIPTION
### Motivation

- Improve type safety and IDE/autocomplete for Playwright launch options by aligning `PlaywrightConfig.launch_kwargs` with the accepted kwargs of `BrowserType.launch()`.
- Replace the untyped `dict[str, Any]` so tooling can catch invalid option names or types at development time.

### Description

- Added a `LaunchKwargs` `TypedDict` that models common `BrowserType.launch()` kwargs (e.g. `executable_path`, `channel`, `args`, `proxy`, `downloads_path`, `firefox_user_prefs`).
- Imported `ProxySettings` and added `pathlib` typing usage for richer, accurate option annotations.
- Replaced `launch_kwargs: dict[str, Any]` with `launch_kwargs: LaunchKwargs` and used `field(default_factory=LaunchKwargs)` to keep the same default behavior.
- Kept runtime behavior unchanged; `lifespan()` still merges `headless` and `launch_kwargs` and forwards them to `browser_type.launch(...)`.

### Testing

- Ran `python -m compileall src/litestar_playwright/config.py`, which succeeded.
- Ran `pytest -q tests/test_config.py` (without `PYTHONPATH`), which failed during collection because the test runner could not import the package in that environment.
- Ran `PYTHONPATH=src pytest -q tests/test_config.py`, which failed because the `playwright` dependency is not installed in the execution environment; tests that mock `async_playwright` should pass in a properly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6de4f8c88323901d711632a272f2)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves type safety for Playwright configuration by replacing the generic `dict[str, Any]` type for `launch_kwargs` with a strongly-typed `LaunchKwargs` TypedDict. The new type definition models all common options accepted by `BrowserType.launch()`, including paths, proxy settings, browser-specific preferences, and various boolean flags. This change enables better IDE autocomplete and compile-time validation of configuration options while preserving the existing runtime behavior.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/litestar_playwright/config.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->