### PR TITLE
ci: add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,48 @@ jobs:
         run: uv run playwright install-deps
       - name: Run the tests
         run: uv run --locked tox run
+      - name: Upload coverage files
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: coverage-${{ matrix.os }}
+          path: .coverage*
+          retention-days: 1
+          include-hidden-files: true
+  coverage:
+    name: Coverage Report
+    needs:
+      - ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+      - name: Setup uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Restore cache
+        if: steps.setup-uv.outputs.cache-hit == 'true'
+        run: echo "Cache was restored"
+      - name: Download coverage files
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage*
+          merge-multiple: true
+      - name: Install coverage
+        run: uv tool install coverage[toml]
+      - name: Coverage Report
+        run: |
+          uv tool run coverage combine
+          uv tool run coverage report
+          uv tool run coverage xml
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v6.0.0
+        with:
+          files: coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run the tests
         run: uv run --locked tox run
       - name: Upload coverage files
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}
           path: .coverage*
@@ -90,7 +90,7 @@ jobs:
         if: steps.setup-uv.outputs.cache-hit == 'true'
         run: echo "Cache was restored"
       - name: Download coverage files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           pattern: coverage*
           merge-multiple: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/litestar-playwright.svg)](https://pypi.org/project/litestar-playwright)
 [![License - MIT](https://img.shields.io/github/license/hasansezertasan/litestar-playwright.svg)](https://opensource.org/licenses/MIT)
 [![Latest Commit](https://img.shields.io/github/last-commit/hasansezertasan/litestar-playwright)](https://github.com/hasansezertasan/litestar-playwright)
+[![Coverage](https://img.shields.io/codecov/c/github/hasansezertasan/litestar-playwright)](https://codecov.io/gh/hasansezertasan/litestar-playwright)
 
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Linted and formatted with Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,11 @@ asyncio_default_fixture_loop_scope = "function"
 source_pkgs = ["litestar_playwright", "tests"]
 branch = true
 parallel = true
-omit = ["src/litestar_playwright/__about__.py"]
+omit = [
+  "src/litestar_playwright/__about__.py",
+  "src/litestar_playwright/_version.py",
+  "*/litestar_playwright/_version.py",
+]
 
 
 [tool.coverage.paths]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,9 @@ commands = [
     "install",
   ],
   [
+    "coverage",
+    "run",
+    "-m",
     "pytest",
     "-v",
     "--tb=short",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,8 @@ omit = ["src/litestar_playwright/__about__.py"]
 litestar_playwright = [
   "src/litestar_playwright",
   "*/litestar-playwright/src/litestar_playwright",
+  "*/site-packages/litestar_playwright",
+  "*\\site-packages\\litestar_playwright",
 ]
 tests = ["tests", "*/litestar-playwright/tests"]
 


### PR DESCRIPTION
## Summary
- Wrap pytest in `coverage run -m pytest` inside tox so test runs emit `.coverage.*` files (subprocess coverage already enabled via `coverage-enable-subprocess`).
- CI matrix jobs upload `.coverage*` as artifacts; new `coverage` job downloads, combines, generates `coverage.xml`, uploads to Codecov via `codecov/codecov-action@v6.0.0`.
- README: Codecov badge.

Mirrors setup used in [openapipages](https://github.com/hasansezertasan/openapipages).

## Test plan
- [ ] CI matrix runs green
- [ ] `coverage` job combines artifacts without conflict
- [ ] Codecov receives report (enable repo on codecov.io; tokenless works for public repos)

## Summary by Sourcery

Upload combined coverage reports from CI to Codecov and expose coverage status in documentation.

New Features:
- Run pytest under coverage in tox to generate coverage data files.
- Upload per-matrix coverage artifacts in CI and aggregate them in a dedicated coverage job.
- Publish coverage reports to Codecov and expose a Codecov badge in the README.