### PR TITLE
fix(lint): reword config property docstring to satisfy ruff

### DIFF
--- a/src/litestar_playwright/plugin.py
+++ b/src/litestar_playwright/plugin.py
@@ -30,7 +30,7 @@ class PlaywrightPlugin(InitPluginProtocol):
 
     @property
     def config(self) -> PlaywrightConfig:
-        """Get the configuration.
+        """The Playwright configuration.
 
         Returns:
             The configuration.


### PR DESCRIPTION
## What

ruff 0.15.x added the `property-docstring-starts-with-verb` rule, which flags `PlaywrightPlugin.config`'s `"""Get the configuration."""` docstring. Reworded it to describe the value (`"""The Playwright configuration."""`).

## Why

The `style` tox env installs `ruff>=0.12.12`, which now resolves to 0.15.18. This broke CI on every open Renovate PR (e.g. #81), even though those bumps are unrelated. Landing the fix on `main` unblocks them once rebased.

## Verification

`ruff 0.15.18 check` → `All checks passed!`

## Summary by Sourcery

Bug Fixes:
- Adjust the Playwright plugin config property docstring to satisfy Ruff's property-docstring-starts-with-verb rule and prevent lint failures.